### PR TITLE
Update Scala and Kotlin carrot demos (BoundedMean)

### DIFF
--- a/doc/kotlin/KotlinCarrotsDemo.ipynb
+++ b/doc/kotlin/KotlinCarrotsDemo.ipynb
@@ -38,7 +38,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a87cb8b8-44ac-4e14-ba04-e95e7b8072ab",
+       "model_id": "2e6d04b9-99d5-4ff3-b9d9-ce91a4f25cf1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -62,7 +62,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fe097a5b-ac3c-4ce8-aa01-23615ffea2a0",
+       "model_id": "7095989b-ad26-4e3c-a5d9-ed2e015ea55a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -86,7 +86,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "79ed546f-d825-4f22-b9a5-d49d4566f411",
+       "model_id": "d99f7dc1-8c89-4c39-aad9-5d8819586218",
        "version_major": 2,
        "version_minor": 0
       },
@@ -110,7 +110,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66f422f2-8a90-49f0-b292-d74f7a83b042",
+       "model_id": "32cb5500-ddd0-49d1-8f02-86c38fec0b7f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -134,7 +134,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7ae08619-47cf-4ef8-8fd8-1fedabebbe6b",
+       "model_id": "a080582a-9c6d-4fe5-9127-fc3d1018575f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -146,7 +146,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "74b786dd-e113-413f-b205-d1bd7e23e09b",
+       "model_id": "7c1eb402-5c2c-43d7-aced-8098a4ce6971",
        "version_major": 2,
        "version_minor": 0
       },
@@ -260,7 +260,8 @@
     "val lowerBound = 0.0\n",
     "val upperBound = 100.0\n",
     "\n",
-    "val maxPartitions = 1"
+    "val maxPartitions = 1\n",
+    "val maxContributions = 1"
    ]
   },
   {
@@ -282,7 +283,7 @@
       "\n",
       "Privacy budget remaining: 4.00\n",
       "True sum: 9649.00\n",
-      "DP sum: 9493.46\n"
+      "DP sum: 9685.70\n"
      ]
     },
     {
@@ -320,7 +321,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here Farmer Fred wants to know the total number of carrot eaters:"
+    "Farmer Fred catches on that the animals are giving him DP results.\n",
+    "\n",
+    "He asks for the mean number of carrots eaten, (TODO: \"but this time, he wants some additional accuracy information to build his intuition.\" requires features yet unavailable in Java)."
    ]
   },
   {
@@ -334,8 +337,8 @@
      "text": [
       "\n",
       "Privacy budget remaining: 3.00\n",
-      "True count: 182\n",
-      "DP count: 181\n"
+      "True mean: 53.02\n",
+      "DP mean: 51.13\n"
      ]
     },
     {
@@ -351,7 +354,61 @@
    ],
    "source": [
     "println(\"\\nPrivacy budget remaining: %.2f\".format(privacyBudget))\n",
-    "val trueCount = carrotsData.size\n",
+    "val trueMean = trueSum / carrotsData.size\n",
+    "println(\"True mean: %.2f\".format(trueMean))\n",
+    "\n",
+    "if (privacyBudget >= queryEpsilon) {\n",
+    "    privacyBudget -= queryEpsilon\n",
+    "    val privateMean = BoundedMean.builder()\n",
+    "                                 .lower(lowerBound)\n",
+    "                                 .upper(upperBound)\n",
+    "                                 .maxPartitionsContributed(maxPartitions)\n",
+    "                                 .maxContributionsPerPartition(maxContributions)\n",
+    "                                 .epsilon(queryEpsilon)\n",
+    "                                 .build()\n",
+    "    privateMean.addEntries(carrotsData)\n",
+    "    val meanResult = privateMean.computeResult()\n",
+    "    println(\"DP mean: %.2f\".format(meanResult))\n",
+    "} else\n",
+    "    println(\"Not enough privacy budget left!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fred wonders how many gluttons are in his zoo. How many animals ate over 90 carrots?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Privacy budget remaining: 2.00\n",
+      "True count: 21\n",
+      "DP count: 19\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "null"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "println(\"\\nPrivacy budget remaining: %.2f\".format(privacyBudget))\n",
+    "val trueCount = carrotsData.filter{ it > 90 }.size\n",
     "println(\"True count: $trueCount\")\n",
     "\n",
     "if (privacyBudget >= queryEpsilon) {\n",
@@ -360,7 +417,7 @@
     "                            .maxPartitionsContributed(maxPartitions)\n",
     "                            .epsilon(queryEpsilon)\n",
     "                            .build()\n",
-    "    privateCount.incrementBy(carrotsData.size)\n",
+    "    privateCount.incrementBy(trueCount)\n",
     "    val countResult = privateCount.computeResult()\n",
     "    println(\"DP count: $countResult\")\n",
     "} else\n",

--- a/doc/scala/ScalaDemo.ipynb
+++ b/doc/scala/ScalaDemo.ipynb
@@ -23,13 +23,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Added new repo: mvnLocal\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "",
@@ -44,31 +37,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac0c31cd-2041-4921-a573-e08a096eac1e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "method": "display_data"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "method": "display_data"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bafc307e-4755-4a2f-975b-cf5f911cbb57",
+       "model_id": "fc7aacab-7754-4f40-9541-8bc3fada6120",
        "version_major": 2,
        "version_minor": 0
       },
@@ -92,7 +61,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f59e0835-67ab-4eff-8fdd-91fa891ba5b9",
+       "model_id": "6a7d0014-cca0-4b2b-aa40-f5ec156fc61f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -116,7 +85,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a8202a03-65b0-4dd7-a4ab-f39f5b06a6ce",
+       "model_id": "17c62586-8772-48ff-8e4d-8009866cff22",
        "version_major": 2,
        "version_minor": 0
       },
@@ -140,7 +109,43 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "19e433c1-5619-4feb-88ed-c90d47bfa283",
+       "model_id": "bafcaab5-3873-4335-b4f8-737a6fb75cb4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "method": "display_data"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "method": "display_data"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d7619e6a-1904-4ebf-ad53-7ece12698dcf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "method": "display_data"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b933075-008e-4281-97da-7057c71a69bd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -152,7 +157,7 @@
     {
      "data": {
       "text/plain": [
-       "scala.collection.JavaConverters$@73aad03c"
+       "scala.collection.JavaConverters$@dc9aaf7"
       ]
      },
      "execution_count": 1,
@@ -261,7 +266,8 @@
     "val lowerBound = 0.0\n",
     "val upperBound = 100.0\n",
     "\n",
-    "val maxPartitions = 1"
+    "val maxPartitions = 1\n",
+    "val maxContributions = 1"
    ]
   },
   {
@@ -283,7 +289,7 @@
       "\n",
       "Privacy budget remaining: 4.00\n",
       "True sum: 9649.00\n",
-      "DP sum: 9636.20\n"
+      "DP sum: 9630.66\n"
      ]
     },
     {
@@ -321,7 +327,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here Farmer Fred wants to know the total number of carrot eaters:"
+    "Farmer Fred catches on that the animals are giving him DP results.\n",
+    "\n",
+    "He asks for the mean number of carrots eaten, (TODO: \"but this time, he wants some additional accuracy information to build his intuition.\" requires features yet unavailable in Java)."
    ]
   },
   {
@@ -335,8 +343,8 @@
      "text": [
       "\n",
       "Privacy budget remaining: 3.00\n",
-      "True count: 182\n",
-      "DP count: 181\n"
+      "True mean: 53.02\n",
+      "DP mean: 53.12\n"
      ]
     },
     {
@@ -352,7 +360,61 @@
    ],
    "source": [
     "print(f\"\\nPrivacy budget remaining: $privacyBudget%.2f\\n\")\n",
-    "val trueCount = carrotsData.size\n",
+    "val trueMean = trueSum / carrotsData.size\n",
+    "print(f\"True mean: $trueMean%.2f\\n\")\n",
+    "\n",
+    "if (privacyBudget >= queryEpsilon) {\n",
+    "    privacyBudget -= queryEpsilon\n",
+    "    val privateMean = BoundedMean.builder()\n",
+    "                                 .lower(lowerBound)\n",
+    "                                 .upper(upperBound)\n",
+    "                                 .maxPartitionsContributed(maxPartitions)\n",
+    "                                 .maxContributionsPerPartition(maxContributions)\n",
+    "                                 .epsilon(queryEpsilon)\n",
+    "                                 .build()\n",
+    "    privateMean.addEntries(carrotsData)\n",
+    "    val meanResult = privateMean.computeResult()\n",
+    "    print(f\"DP mean: $meanResult%.2f\\n\")\n",
+    "} else\n",
+    "    print(\"Not enough privacy budget left!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fred wonders how many gluttons are in his zoo. How many animals ate over 90 carrots?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Privacy budget remaining: 2.00\n",
+      "True count: 21\n",
+      "DP count: 20\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "null"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(f\"\\nPrivacy budget remaining: $privacyBudget%.2f\\n\")\n",
+    "val trueCount = carrotsScalaData.filter(_ > 90).size\n",
     "print(f\"True count: $trueCount%d\\n\")\n",
     "\n",
     "if (privacyBudget >= queryEpsilon) {\n",
@@ -361,7 +423,7 @@
     "                            .maxPartitionsContributed(maxPartitions)\n",
     "                            .epsilon(queryEpsilon)\n",
     "                            .build()\n",
-    "    privateCount.incrementBy(carrotsData.size)\n",
+    "    privateCount.incrementBy(trueCount)\n",
     "    val countResult = privateCount.computeResult()\n",
     "    print(f\"DP count: $countResult%d\\n\")\n",
     "} else\n",


### PR DESCRIPTION
## Description
Adds BoundedMean to Scala and Kotlin notebooks. Also makes notebooks follow original carrots demo more closely (CountAbove).

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
