### PR TITLE
Small cleanup in Clojure notebook

### DIFF
--- a/doc/clojure/ClojureCarrotsDemo.ipynb
+++ b/doc/clojure/ClojureCarrotsDemo.ipynb
@@ -283,7 +283,8 @@
     ";; privately inferred bounds so these have to be set manually:\n",
     "(def lower-bound 0.0)\n",
     "(def upper-bound 100.0)\n",
-    "(def max-partitions 1)"
+    "(def max-partitions 1)\n",
+    "(def max-contributions 1)"
    ]
   },
   {
@@ -382,8 +383,8 @@
     "          dp-mean (dp/bounded-mean carrots-consumption-data\n",
     "                                   :lower lower-bound\n",
     "                                   :upper upper-bound\n",
-    "                                   :max-contributions-per-partition 1\n",
-    "                                   :max-partitions-contributed 1\n",
+    "                                   :max-contributions-per-partition max-contributions\n",
+    "                                   :max-partitions-contributed max-partitions\n",
     "                                   :epsilon query-epsilon)]\n",
     "        (swap! privacy-budget - query-epsilon)\n",
     "        (printf \"True mean: %.2f\\n\" true-mean)\n",
@@ -431,7 +432,7 @@
     "    (println \"Not enough privacy budget left!\")\n",
     "    (let [true-count (count (filter #(> % 90) carrots-consumption-data))\n",
     "          dp-count (dp/count (filter #(> % 90) carrots-consumption-data)\n",
-    "                             :max-partitions-contributed 1\n",
+    "                             :max-partitions-contributed max-partitions\n",
     "                             :epsilon query-epsilon)]\n",
     "        (swap! privacy-budget - query-epsilon)\n",
     "        (println \"True count:\" true-count)\n",


### PR DESCRIPTION
## Description

Algorithm parameters in Clojure carrots demo are now named like in other notebooks.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
